### PR TITLE
Add pytest and tests for process_dataframe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas>=2.3
 streamlit>=1.35
 openpyxl
 xlsxwriter
+pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pandas as pd
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core.utils import process_dataframe
+
+
+def test_process_dataframe_sudachi_match():
+    df = pd.DataFrame({
+        '名前': ['太郎', '花子'],
+        'フリガナ': ['タロウ', 'ハナコ'],
+    })
+
+    with patch('core.utils.scorer.gpt_candidates', return_value=[] ) as mock:
+        out = process_dataframe(df, '名前', 'フリガナ')
+
+    assert list(out['信頼度']) == [95, 95]
+    assert list(out['理由']) == ['辞書候補1位一致', '辞書候補1位一致']
+    assert mock.call_count == 0


### PR DESCRIPTION
## Summary
- add `pytest` to requirements
- test `process_dataframe` with Sudachi matches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6a7a8b0883338dda28c311d2bc5a