### PR TITLE
Add Sudachi parser tests

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core import parser
+
+
+def test_sudachi_reading_known():
+    assert parser.sudachi_reading("太郎") == "タロウ"
+
+
+def test_sudachi_reading_latin():
+    # Sudachi handles latin letters by transliteration
+    assert parser.sudachi_reading("John") == "ジョン"


### PR DESCRIPTION
## Summary
- test `sudachi_reading` for Japanese and Latin names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b6cab8a1c8333906b468de739613d