### PR TITLE
Improve Excel output formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ if not os.getenv("OPENAI_API_KEY"):
 uploaded = st.file_uploader("Excelを選択", type=["xlsx"])
 
 if "df" not in st.session_state and uploaded:
+    st.session_state.template_bytes = uploaded.getvalue()
     st.session_state.df = pd.read_excel(uploaded)
 
 if "df" in st.session_state:
@@ -38,7 +39,8 @@ if "df" in st.session_state:
 if "out_df" in st.session_state:
     st.write("結果プレビュー:")
     st.dataframe(st.session_state.out_df.head())
-    bytes_data = to_excel_bytes(st.session_state.out_df)
+    tmpl = st.session_state.get("template_bytes")
+    bytes_data = to_excel_bytes(st.session_state.out_df, template_bytes=tmpl)
     st.download_button(
         label="保存してダウンロード",
         data=bytes_data,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,9 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core.utils import process_dataframe
 from core import scorer
+from core.utils import to_excel_bytes
+from openpyxl import load_workbook, Workbook
+from io import BytesIO
 
 
 def test_process_dataframe_sudachi_match():
@@ -46,3 +49,17 @@ def test_process_dataframe_gpt_called():
     assert out['信頼度'][0] == 85
     assert out['理由'][0] == '候補1位一致'
     conf_mock.assert_called_once()
+
+
+def test_to_excel_bytes_template():
+    df = pd.DataFrame({"A": [1]})
+    wb = Workbook()
+    ws = wb.active
+    ws["A1"] = "old"
+    buf = BytesIO()
+    wb.save(buf)
+    tmpl = buf.getvalue()
+
+    out_bytes = to_excel_bytes(df, template_bytes=tmpl)
+    wb2 = load_workbook(BytesIO(out_bytes))
+    assert wb2.active["A2"].value == 1


### PR DESCRIPTION
## Summary
- store uploaded Excel bytes in session state
- preserve formatting when exporting results with `to_excel_bytes`
- test Excel byte output when using a template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6d83b8bc83339a2d3eb7cf2df49c