### PR TITLE
Handle OpenAI transient errors

### DIFF
--- a/core/scorer.py
+++ b/core/scorer.py
@@ -12,7 +12,7 @@ def _call_with_backoff(**kwargs):
     for _ in range(5):
         try:
             return client.chat.completions.create(**kwargs)
-        except openai.RateLimitError:
+        except (openai.RateLimitError, openai.OpenAIError):
             time.sleep(delay)
             delay *= 2
     return client.chat.completions.create(**kwargs)

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from unittest.mock import patch
+import openai
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from core import scorer
+
+
+def test_call_with_backoff_retries_api_connection_error():
+    success = object()
+    responses = [openai.APIConnectionError(message="fail", request=None), success]
+
+    def side_effect(*args, **kwargs):
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    with patch("core.scorer.client.chat.completions.create", side_effect=side_effect) as mock_create, \
+         patch("time.sleep") as sleep_mock:
+        result = scorer._call_with_backoff(model="dummy", messages=[])
+
+    assert result is success
+    assert mock_create.call_count == 2
+    sleep_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- retry `_call_with_backoff` on `openai.OpenAIError` in addition to `RateLimitError`
- add regression test covering transient `APIConnectionError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bb86d46b48333a467836dbcc625b5