### PR TITLE
Simplify test imports with conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Append the repository root so tests can import the package
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,3 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core import parser
 
 

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,10 +1,7 @@
-import os
-import sys
 from unittest.mock import patch
 import types
 import openai
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core import scorer
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,6 @@
-import os
-import sys
-
 import pandas as pd
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from core.utils import process_dataframe
 from core import scorer
 from core.utils import to_excel_bytes


### PR DESCRIPTION
## Summary
- create `tests/conftest.py` to add the repo root to `sys.path`
- clean up individual path modification in each test module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc9e6f0548333bfad36a5dad352cc