### PR TITLE
Add empty-string test for sudachi_reading

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,3 +8,7 @@ def test_sudachi_reading_known():
 def test_sudachi_reading_latin():
     # Sudachi handles latin letters by transliteration
     assert parser.sudachi_reading("John") == "ジョン"
+
+
+def test_sudachi_reading_empty():
+    assert parser.sudachi_reading("") is None


### PR DESCRIPTION
## Summary
- add a test checking `sudachi_reading('')` returns `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcbccc5dc8333b12cdf426e74e060