### PR TITLE
Configure flake8 and wrap test code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,3 @@ from pathlib import Path
 # Append the repository root so tests can import the package
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
-

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -15,8 +15,10 @@ def test_call_with_backoff_retries_api_connection_error():
             raise result
         return result
 
-    with patch("core.scorer.client.chat.completions.create", side_effect=side_effect) as mock_create, \
-         patch("time.sleep") as sleep_mock:
+    with patch(
+        "core.scorer.client.chat.completions.create",
+        side_effect=side_effect,
+    ) as mock_create, patch("time.sleep") as sleep_mock:
         result = scorer._call_with_backoff(model="dummy", messages=[])
 
     assert result is success

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ def test_process_dataframe_sudachi_match():
         'フリガナ': ['タロウ', 'ハナコ'],
     })
 
-    with patch('core.utils.scorer.gpt_candidates', return_value=[] ) as mock:
+    with patch('core.utils.scorer.gpt_candidates', return_value=[]) as mock:
         out = process_dataframe(df, '名前', 'フリガナ')
 
     assert list(out['信頼度']) == [95, 95]
@@ -37,9 +37,16 @@ def test_process_dataframe_long_name():
 def test_process_dataframe_gpt_called():
     df = pd.DataFrame({'名前': ['未知'], 'フリガナ': ['ミチ']})
 
-    with patch('core.utils.parser.sudachi_reading', return_value=None), \
-         patch('core.utils.scorer.gpt_candidates', return_value=['ミチ', 'ミチョ']), \
-         patch('core.utils.scorer.calc_confidence', wraps=scorer.calc_confidence) as conf_mock:
+    with patch(
+        'core.utils.parser.sudachi_reading',
+        return_value=None,
+    ), patch(
+        'core.utils.scorer.gpt_candidates',
+        return_value=['ミチ', 'ミチョ'],
+    ), patch(
+        'core.utils.scorer.calc_confidence',
+        wraps=scorer.calc_confidence,
+    ) as conf_mock:
         out = process_dataframe(df, '名前', 'フリガナ')
 
     assert out['信頼度'][0] == 85
@@ -61,7 +68,7 @@ def test_process_dataframe_nan_name():
 def test_process_dataframe_nan_furigana():
     df = pd.DataFrame({'名前': ['太郎'], 'フリガナ': [pd.NA]})
 
-    with patch('core.utils.scorer.gpt_candidates', return_value=['タロウ'] ) as mock:
+    with patch('core.utils.scorer.gpt_candidates', return_value=['タロウ']) as mock:
         out = process_dataframe(df, '名前', 'フリガナ')
 
     assert out['信頼度'][0] == 30


### PR DESCRIPTION
## Summary
- configure flake8 with an 88 character limit
- fix trailing newline in `conftest`
- wrap long `patch` lines in tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bce196cd483339a24df08d72818ab