### PR TITLE
Add caching for sudachi_reading

### DIFF
--- a/core/parser.py
+++ b/core/parser.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from sudachipy import dictionary, tokenizer
+from functools import lru_cache
 
 # Initialize Sudachi tokenizer with full dictionary once
 TOKENIZER = dictionary.Dictionary(dict="full").create()
 MODE = tokenizer.Tokenizer.SplitMode.C
 
 
+@lru_cache(maxsize=1024)
 def sudachi_reading(name: str) -> str | None:
     """Return katakana reading for `name` using SudachiPy."""
     if not name:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,11 @@
 from core import parser
+from unittest.mock import patch
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    parser.sudachi_reading.cache_clear()
 
 
 def test_sudachi_reading_known():
@@ -12,3 +19,13 @@ def test_sudachi_reading_latin():
 
 def test_sudachi_reading_empty():
     assert parser.sudachi_reading("") is None
+
+
+def test_sudachi_reading_cached():
+    with patch.object(parser, "TOKENIZER", wraps=parser.TOKENIZER) as mock_tok:
+        first = parser.sudachi_reading("太郎")
+        second = parser.sudachi_reading("太郎")
+
+    assert first == "タロウ"
+    assert second == "タロウ"
+    assert mock_tok.tokenize.call_count == 1


### PR DESCRIPTION
## Summary
- memoize `sudachi_reading` in `parser.py` using `lru_cache`
- ensure caches are cleared between tests
- add a unit test checking tokenizer is not invoked twice for the same name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd2b03b408333b4cac3e22d676a79