### PR TITLE
Implement SQLite cache for furigana results

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import streamlit as st
 from core.utils import process_dataframe, to_excel_bytes
+from core import db
 
 EXCEL_MIME = (
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -10,6 +11,7 @@ EXCEL_MIME = (
 
 st.set_page_config(page_title="Furigana Checker")
 st.title("Excel フリガナ信頼度チェッカー")
+DB_CONN = db.init_db()
 
 if not os.getenv("OPENAI_API_KEY"):
     st.warning("OPENAI_API_KEY環境変数が設定されていません")
@@ -36,7 +38,7 @@ if "df" in st.session_state:
             progress.progress(done / total)
 
         with st.spinner("解析中..."):
-            out_df = process_dataframe(df, name_col, furi_col, on_progress)
+            out_df = process_dataframe(df, name_col, furi_col, on_progress, db_conn=DB_CONN)
         progress.empty()
         st.session_state.out_df = out_df
 

--- a/core/db.py
+++ b/core/db.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def init_db(path: str | Path = "furigana.db") -> sqlite3.Connection:
+    """Initialize and return a SQLite connection."""
+    conn = sqlite3.connect(path)
+    with conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS readings ("
+            "name TEXT NOT NULL,"
+            "reading TEXT NOT NULL,"
+            "confidence INTEGER NOT NULL,"
+            "reason TEXT NOT NULL,"
+            "PRIMARY KEY(name, reading)"
+            ")"
+        )
+    return conn
+
+
+def get_reading(
+    name: str, reading: str, conn: sqlite3.Connection
+) -> Optional[Tuple[int, str]]:
+    """Retrieve cached confidence and reason for ``name`` and ``reading``."""
+    cur = conn.execute(
+        "SELECT confidence, reason FROM readings WHERE name=? AND reading=?",
+        (name, reading),
+    )
+    row = cur.fetchone()
+    if row:
+        return int(row[0]), row[1]
+    return None
+
+
+def save_reading(
+    name: str,
+    reading: str,
+    confidence: int,
+    reason: str,
+    conn: sqlite3.Connection,
+) -> None:
+    """Save result to the database."""
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO readings (name, reading, confidence, reason) "
+            "VALUES (?, ?, ?, ?)",
+            (name, reading, confidence, reason),
+        )
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,25 @@
+import sqlite3
+import pandas as pd
+from core import db
+from core.utils import process_dataframe
+from unittest.mock import patch
+
+def test_db_round_trip(tmp_path):
+    path = tmp_path / 'cache.db'
+    conn = db.init_db(path)
+    db.save_reading('太郎', 'タロウ', 90, 'cached', conn)
+    assert db.get_reading('太郎', 'タロウ', conn) == (90, 'cached')
+
+
+def test_process_dataframe_uses_cache(tmp_path):
+    path = tmp_path / 'c.db'
+    conn = db.init_db(path)
+    db.save_reading('太郎', 'タロウ', 88, 'cache', conn)
+    df = pd.DataFrame({'名前': ['太郎'], 'フリガナ': ['タロウ']})
+    with patch('core.utils.parser.sudachi_reading') as p_mock, patch('core.utils.scorer.gpt_candidates') as g_mock:
+        out = process_dataframe(df, '名前', 'フリガナ', db_conn=conn)
+    assert out['信頼度'][0] == 88
+    assert out['理由'][0] == 'cache'
+    p_mock.assert_not_called()
+    g_mock.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add `core.db` helper for persisting processed readings
- extend `process_dataframe` with optional SQLite cache
- initialize the cache in `app.py`
- test caching logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd428e3ec8333ae0d51800b33d3fb