### PR TITLE
Add configurable DB path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Set your OpenAI API key:
 export OPENAI_API_KEY="sk-..."
 ```
 
+Optionally specify the SQLite cache location:
+
+```bash
+export FURIGANA_DB="/path/to/cache.db"
+```
+
 ## Usage
 
 Run the app locally:

--- a/core/db.py
+++ b/core/db.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
+import os
 import sqlite3
 from pathlib import Path
 from typing import Optional, Tuple
 
 
-def init_db(path: str | Path = "furigana.db") -> sqlite3.Connection:
-    """Initialize and return a SQLite connection."""
+def init_db(path: str | Path | None = None) -> sqlite3.Connection:
+    """Initialize and return a SQLite connection.
+
+    If ``path`` is ``None`` the location is taken from the ``FURIGANA_DB``
+    environment variable and defaults to ``furigana.db``.  Parent directories
+    are created automatically.
+    """
+    if path is None:
+        path = os.getenv("FURIGANA_DB", "furigana.db")
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     with conn:
         conn.execute(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,5 @@
 import sqlite3
+from pathlib import Path
 import pandas as pd
 from core import db
 from core.utils import process_dataframe
@@ -9,6 +10,13 @@ def test_db_round_trip(tmp_path):
     conn = db.init_db(path)
     db.save_reading('太郎', 'タロウ', 90, 'cached', conn)
     assert db.get_reading('太郎', 'タロウ', conn) == (90, 'cached')
+
+
+def test_init_db_uses_env_var(tmp_path, monkeypatch):
+    path = tmp_path / 'sub' / 'c.db'
+    monkeypatch.setenv('FURIGANA_DB', str(path))
+    conn = db.init_db()
+    assert Path(conn.execute('PRAGMA database_list').fetchone()[2]) == path
 
 
 def test_process_dataframe_uses_cache(tmp_path):


### PR DESCRIPTION
## Summary
- allow `FURIGANA_DB` env var to define cache DB location
- document the new environment variable
- test `init_db` uses the env var

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd6c1c90083338d4785bd1d50e40c