### PR TITLE
Implement deduplication for sync processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ export FURIGANA_DB="/path/to/cache.db"
 ```
 
 The ``process_dataframe`` helper accepts an optional ``batch_size`` argument
-to control how many rows are processed at once (default ``50``).
+to control how many rows are processed at once (default ``50``). Duplicate
+names are consolidated globally before querying the GPT API.
 
 ## Usage
 
@@ -42,9 +43,9 @@ streamlit run app.py
 
 Upload an Excel file, select the name and furigana columns, and download the result with confidence scores.
 
-The library now also exposes ``async_process_dataframe`` for asynchronous
-processing with limited concurrency. Duplicate names are consolidated so GPT is
-called only once per unique value, further reducing runtime on large inputs.
+Both ``process_dataframe`` and ``async_process_dataframe`` now consolidate
+duplicate names so the GPT API is invoked only once per unique value. The async
+variant additionally allows limited concurrency for further speedups.
 
 For details on the async implementation and tuning options, see
 [docs/performance_plan.md](docs/performance_plan.md).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,3 +157,16 @@ def test_async_process_dataframe_deduplicates():
     result = asyncio.run(run_test())
     assert list(result['信頼度']) == [85, 85]
     assert list(result['理由']) == ['候補1位一致', '候補1位一致']
+
+
+def test_process_dataframe_deduplicates():
+    df = pd.DataFrame({'名前': ['未知', '未知'], 'フリガナ': ['ミチ', 'ミチ']})
+
+    with patch('core.utils.parser.sudachi_reading', return_value=None), patch(
+        'core.utils.scorer.gpt_candidates', return_value=['ミチ']
+    ) as g_mock:
+        out = process_dataframe(df, '名前', 'フリガナ', batch_size=1)
+
+    assert g_mock.call_count == 1
+    assert list(out['信頼度']) == [85, 85]
+    assert list(out['理由']) == ['候補1位一致', '候補1位一致']


### PR DESCRIPTION
## Summary
- deduplicate names in `process_dataframe` just like the async version
- add unit test covering sync deduplication
- clarify batch size docs

## Testing
- `pip install sudachipy sudachidict-full openai pandas streamlit openpyxl xlsxwriter`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cbd2e7898833394c917607b2397e4