### PR TITLE
Use as_completed for async results

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -175,11 +175,11 @@ async def async_process_dataframe(
         for start in range(0, len(names), batch_size):
             chunk = names[start:start + batch_size]
             tasks = [fetch_candidates(n) for n in chunk]
-            results = await asyncio.gather(*tasks)
-            name_to_cands = {n: c for n, c in results}
+            name_to_cands = {}
 
-            for name in chunk:
-                candidates = name_to_cands.get(name, [])
+            for coro in asyncio.as_completed(tasks):
+                name, candidates = await coro
+                name_to_cands[name] = candidates
                 for idx, reading in pending[name]:
                     conf, reason = scorer.calc_confidence(reading, candidates)
                     confs[idx] = conf


### PR DESCRIPTION
## Summary
- refactor `async_process_dataframe` to process tasks as they finish using `asyncio.as_completed`
- update progress reporting for each completed name

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc561ee388333b1031da1c383152d