### PR TITLE
Use xlsxwriter for new Excel files

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -221,6 +221,6 @@ def to_excel_bytes(
         return buf.getvalue()
     else:
         buf = BytesIO()
-        with pd.ExcelWriter(buf, engine="openpyxl") as writer:
+        with pd.ExcelWriter(buf, engine="xlsxwriter") as writer:
             df.to_excel(writer, index=False)
         return buf.getvalue()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,6 +98,23 @@ def test_to_excel_bytes_no_template():
     assert wb.active["A2"].value == 2
 
 
+def test_to_excel_bytes_uses_xlsxwriter():
+    df = pd.DataFrame({"A": [3]})
+    call_engines = []
+    orig_writer = pd.ExcelWriter
+
+    def spy_writer(*args, **kwargs):
+        call_engines.append(kwargs.get("engine"))
+        return orig_writer(*args, **kwargs)
+
+    with patch("pandas.ExcelWriter", side_effect=spy_writer):
+        out_bytes = to_excel_bytes(df)
+
+    assert call_engines[0] == "xlsxwriter"
+    wb = load_workbook(BytesIO(out_bytes))
+    assert wb.active["A2"].value == 3
+
+
 def test_process_dataframe_progress_and_batch_size():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- when saving DataFrames without a template use `xlsxwriter`
- test that the engine selection is correct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccad4b4048333a330b11b74ee6cf4