### PR TITLE
Update OpenAI API parameters

### DIFF
--- a/core/scorer.py
+++ b/core/scorer.py
@@ -44,7 +44,8 @@ def gpt_candidates(name: str) -> List[str]:
         model=DEFAULT_MODEL,
         messages=[{"role": "user", "content": prompt1}],
         temperature=0.0,
-        logprobs=5,
+        logprobs=True,
+        top_logprobs=5,
         n=1,
     )
     top = res1.choices[0].message.content.strip()
@@ -81,7 +82,8 @@ async def async_gpt_candidates(name: str) -> List[str]:
             model=DEFAULT_MODEL,
             messages=[{"role": "user", "content": prompt1}],
             temperature=0.0,
-            logprobs=5,
+            logprobs=True,
+            top_logprobs=5,
             n=1,
         ),
         _acall_with_backoff(


### PR DESCRIPTION
## Summary
- use `logprobs=True` and `top_logprobs=5` for GPT calls
- keep async variant consistent with the sync code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db99ed80c83339dd60481a5801089