### PR TITLE
Adjust GPT candidate temperatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ produce consistent results:
    character ``ﾀﾞ`` or the base character ``ﾀ`` followed by ``ﾞ``.
 3. Characters like ``ヲ`` and ``ー`` are entered as is without conversion.
 
+### Candidate Generation
+
+Unknown names are sent to GPT-4o mini twice with different temperatures. The
+first request uses ``temperature=0.2`` and returns three candidates. The second
+uses ``temperature=0.5`` and returns five more. Duplicate readings are removed
+before scoring.
+
 ## Usage
 
 Run the app locally. The Streamlit interface now leverages the asynchronous

--- a/core/scorer.py
+++ b/core/scorer.py
@@ -52,7 +52,7 @@ async def _acall_with_backoff(**kwargs):
 def gpt_candidates(name: str) -> List[str]:
     """Return candidate readings using multi-temperature prompts."""
     prompt = f"{name} の読みをカタカナで答えて"
-    configs = [(0.0, 3), (2.0, 5), (5.0, 5)]
+    configs = [(0.2, 3), (0.5, 5)]
 
     cand: List[str] = []
     seen = set()
@@ -78,7 +78,7 @@ def gpt_candidates(name: str) -> List[str]:
 async def async_gpt_candidates(name: str) -> List[str]:
     """Async version of ``gpt_candidates`` using multiple temperatures."""
     prompt = f"{name} の読みをカタカナで答えて"
-    configs = [(0.0, 3), (2.0, 5), (5.0, 5)]
+    configs = [(0.2, 3), (0.5, 5)]
 
     tasks = [
         _acall_with_backoff(

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -42,13 +42,7 @@ def test_gpt_candidates_caches_result():
             for _ in range(5)
         ]
     )
-    resp3 = types.SimpleNamespace(
-        choices=[
-            types.SimpleNamespace(message=types.SimpleNamespace(content="カナ5"))
-            for _ in range(5)
-        ]
-    )
-    responses = [resp1, resp2, resp3]
+    responses = [resp1, resp2]
 
     def side_effect(**kwargs):
         return responses.pop(0)
@@ -57,9 +51,9 @@ def test_gpt_candidates_caches_result():
         first = scorer.gpt_candidates("太郎")
         second = scorer.gpt_candidates("太郎")
 
-    assert first == ["カナ1", "カナ2", "カナ3", "カナ4", "カナ5"]
-    assert second == ["カナ1", "カナ2", "カナ3", "カナ4", "カナ5"]
-    assert mock_call.call_count == 3
+    assert first == ["カナ1", "カナ2", "カナ3", "カナ4"]
+    assert second == ["カナ1", "カナ2", "カナ3", "カナ4"]
+    assert mock_call.call_count == 2
 
 
 def test_gpt_candidates_uses_env_var(monkeypatch):
@@ -81,14 +75,8 @@ def test_gpt_candidates_uses_env_var(monkeypatch):
             for _ in range(5)
         ]
     )
-    resp3 = types.SimpleNamespace(
-        choices=[
-            types.SimpleNamespace(message=types.SimpleNamespace(content="カナ5"))
-            for _ in range(5)
-        ]
-    )
     with patch(
-        "core.scorer._call_with_backoff", side_effect=[resp1, resp2, resp3]
+        "core.scorer._call_with_backoff", side_effect=[resp1, resp2]
     ) as mock_call:
         mod.gpt_candidates("太郎")
 
@@ -119,21 +107,14 @@ def test_async_gpt_candidates():
             for _ in range(5)
         ]
     )
-    resp3 = types.SimpleNamespace(
-        choices=[
-            types.SimpleNamespace(message=types.SimpleNamespace(content="カナ5"))
-            for _ in range(5)
-        ]
-    )
-
     async def run_test():
         with patch(
             "core.scorer._acall_with_backoff",
-            new=AsyncMock(side_effect=[resp1, resp2, resp3]),
+            new=AsyncMock(side_effect=[resp1, resp2]),
         ) as mock_call:
             result = await scorer.async_gpt_candidates("太郎")
-        assert result == ["カナ1", "カナ2", "カナ3", "カナ4", "カナ5"]
-        assert mock_call.call_count == 3
+        assert result == ["カナ1", "カナ2", "カナ3", "カナ4"]
+        assert mock_call.call_count == 2
 
     asyncio.run(run_test())
 
@@ -162,24 +143,14 @@ def test_gpt_candidates_normalizes_duplicates():
                 types.SimpleNamespace(
                     message=types.SimpleNamespace(content="ミヤガワ アキ")
                 )
-                for _ in range(5)
+                for _ in range(4)
             ],
-        ]
-    )
-    resp3 = types.SimpleNamespace(
-        choices=[
             types.SimpleNamespace(
                 message=types.SimpleNamespace(content="ミヤカワ アキ")
             ),
-            *[
-                types.SimpleNamespace(
-                    message=types.SimpleNamespace(content="ミヤガワ アキ")
-                )
-                for _ in range(4)
-            ],
         ]
     )
-    with patch("core.scorer._call_with_backoff", side_effect=[resp1, resp2, resp3]):
+    with patch("core.scorer._call_with_backoff", side_effect=[resp1, resp2]):
         result = scorer.gpt_candidates("宮川亜紀")
 
     assert result == ["ミヤガワアキ", "ミヤカワアキ"]


### PR DESCRIPTION
## Summary
- use temperatures 0.2 and 0.5 for GPT candidate generation
- update async helper accordingly
- tweak unit tests for the new configuration
- document candidate generation temperatures in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6335e484833387b8ea38021c09b3