### PR TITLE
Fix blank candidate results

### DIFF
--- a/core/scorer.py
+++ b/core/scorer.py
@@ -13,14 +13,18 @@ async_client = openai.AsyncOpenAI()
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 # regex for the first katakana sequence; also accepts half/full-width digits
-_KANA_RE = re.compile(r"[\u30A0-\u30FF\u30FC0-9\uFF10-\uFF19\s]+")
+# match contiguous katakana or full/half width digits
+_KANA_RE = re.compile(r"[\u30A0-\u30FF\u30FC0-9\uFF10-\uFF19]+")
 
 
 def _clean_reading(text: str) -> str:
     """Return normalized candidate reading from GPT output."""
-    m = _KANA_RE.search(text)
-    if m:
-        text = m.group(0)
+    text = text.lstrip()
+    parts = _KANA_RE.findall(text)
+    if parts:
+        text = "".join(parts)
+    else:
+        text = text.replace(" ", "").replace("　", "")
     return normalize_kana(text)
 
 

--- a/scripts/show_candidates.py
+++ b/scripts/show_candidates.py
@@ -39,8 +39,9 @@ async def fetch(name: str):
             temperature=temp,
             n=n,
         )
-        cands = [_clean_reading(c.message.content.strip()) for c in res.choices]
-        steps.append((temp, cands))
+        raw = [c.message.content.strip() for c in res.choices]
+        cands = [_clean_reading(r) for r in raw]
+        steps.append((temp, raw, cands))
         for c in cands:
             if c not in seen:
                 seen.add(c)
@@ -52,7 +53,8 @@ async def main():
         steps, unique = await fetch(name)
         print(f"名前: {name}\n入力フリガナ: {furi}")
         print(f"Sudachi: {parser.sudachi_reading(name)}")
-        for temp, cands in steps:
+        for temp, raw, cands in steps:
+            print(f"temperature {temp} raw: {raw}")
             print(f"temperature {temp}: {', '.join(cands)}")
         print(f"unique candidates: {', '.join(unique)}")
         print('-'*40)


### PR DESCRIPTION
## Summary
- tweak regex logic used to extract kana from GPT responses
- join multiple kana spans when cleaning output
- show raw candidate strings in `scripts/show_candidates.py` for debugging

## Testing
- `pytest -q`
- `python -m scripts.show_candidates > /tmp/raw_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e7f1c64fc8333a3bccd50b9c34dd8