### PR TITLE
Add presence penalty for GPT candidates

### DIFF
--- a/core/scorer.py
+++ b/core/scorer.py
@@ -66,6 +66,7 @@ def gpt_candidates(name: str) -> List[str]:
             messages=[{"role": "user", "content": prompt}],
             temperature=temp,
             n=n,
+            presence_penalty=1.0,
         )
         for c in res.choices:
             norm = _clean_reading(c.message.content.strip())
@@ -90,6 +91,7 @@ async def async_gpt_candidates(name: str) -> List[str]:
             messages=[{"role": "user", "content": prompt}],
             temperature=temp,
             n=n,
+            presence_penalty=1.0,
         )
         for temp, n in configs
     ]


### PR DESCRIPTION
## Summary
- ensure OpenAI requests encourage unique outputs by applying a presence penalty in candidate generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1435fc948333947050cc5b52ebbd