### PR TITLE
Implement keypuncher normalization

### DIFF
--- a/core/normalize.py
+++ b/core/normalize.py
@@ -1,5 +1,28 @@
 from __future__ import annotations
 import unicodedata
+import jaconv
+
+# mapping for youon expansion used by ``normalize_for_keypuncher_check``
+_YOON_BASES = [
+    "キ",
+    "シ",
+    "チ",
+    "ニ",
+    "ヒ",
+    "ミ",
+    "リ",
+    "ギ",
+    "ジ",
+    "ヂ",
+    "ビ",
+    "ピ",
+]
+
+MAPPING_YOUON = {
+    base + small: base + repl
+    for base in _YOON_BASES
+    for small, repl in zip("ャュョ", "ヤユヨ")
+}
 
 
 def normalize_kana(text: str | None) -> str:
@@ -11,3 +34,32 @@ def normalize_kana(text: str | None) -> str:
         return ""
     out = unicodedata.normalize("NFKC", text)
     return out.replace(" ", "").replace("　", "")
+
+
+def normalize_for_keypuncher_check(text: str | None) -> str:
+    """Return reading normalized to keypuncher format.
+
+    This follows the three step process outlined in ``AGENT２.md``:
+
+    1. Normalize to full-width katakana (NFKC) and remove spaces.
+    2. Expand yo-on combinations (キャ -> キヤ, etc.).
+    3. Convert to half-width with decomposed dakuten/handakuten.
+    """
+
+    if not text:
+        return ""
+
+    # step1: NFKC -> full-width katakana
+    out = unicodedata.normalize("NFKC", text)
+    out = out.replace(" ", "").replace("　", "")
+    out = "".join(
+        chr(ord(ch) + 0x60) if "ぁ" <= ch <= "ゖ" else ch
+        for ch in out
+    )
+
+    # step2: expand yo-on characters
+    for pat, repl in MAPPING_YOUON.items():
+        out = out.replace(pat, repl)
+
+    # step3: half-width conversion with dakuten split
+    return jaconv.z2h(out, kana=True, digit=True, ascii=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pandas>=2.3
 streamlit>=1.35
 openpyxl
 xlsxwriter
+jaconv
 pytest

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,13 @@
+from core.normalize import normalize_for_keypuncher_check
+
+
+def test_normalize_simple():
+    assert normalize_for_keypuncher_check('わたなべ キョウコ') == 'ﾜﾀﾅﾍﾞｷﾖｳｺ'
+
+
+def test_normalize_table_example1():
+    assert normalize_for_keypuncher_check('ババジョウジ') == 'ﾊﾞﾊﾞｼﾞﾖｳｼﾞ'
+
+
+def test_normalize_table_example2():
+    assert normalize_for_keypuncher_check('タカハシダイスケ') == 'ﾀｶﾊｼﾀﾞｲｽｹ'


### PR DESCRIPTION
## Summary
- implement `normalize_for_keypuncher_check` following AGENT２.md
- add `jaconv` dependency
- test normalization examples

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b196d74483339b4cc15d4a09330e