### PR TITLE
Update normalization logic for keypuncher rules

### DIFF
--- a/core/scorer.py
+++ b/core/scorer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import List
-from .normalize import normalize_kana
+from .normalize import normalize_kana, normalize_for_keypuncher_check
 import time
 import os
 import asyncio
@@ -114,9 +114,9 @@ async def async_gpt_candidates(name: str) -> List[str]:
 
 def calc_confidence(row_reading: str, candidates: List[str]) -> tuple[int, str]:
     """Return confidence percentage and short reason."""
-    target = normalize_kana(row_reading)
+    target = normalize_for_keypuncher_check(row_reading)
     for idx, reading in enumerate(candidates, start=1):
-        if target == normalize_kana(reading):
+        if target == normalize_for_keypuncher_check(reading):
             if idx == 1:
                 return 85, "候補1位一致"
             elif idx <= 3:

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pandas as pd
 from io import BytesIO
 from . import parser, scorer, db
-from .normalize import normalize_kana
+from .normalize import normalize_kana, normalize_for_keypuncher_check
 import sqlite3
 import asyncio
 from asyncio import Semaphore
@@ -72,7 +72,7 @@ def process_dataframe(
                 continue
 
         sudachi_kana = parser.sudachi_reading(name)
-        if sudachi_kana and normalize_kana(sudachi_kana) == normalize_kana(reading):
+        if sudachi_kana and normalize_for_keypuncher_check(sudachi_kana) == normalize_for_keypuncher_check(reading):
             confs[idx] = 95
             reasons[idx] = "辞書候補1位一致"
             processed += 1
@@ -164,7 +164,7 @@ async def async_process_dataframe(
                 continue
 
         sudachi_kana = parser.sudachi_reading(name)
-        if sudachi_kana and normalize_kana(sudachi_kana) == normalize_kana(reading):
+        if sudachi_kana and normalize_for_keypuncher_check(sudachi_kana) == normalize_for_keypuncher_check(reading):
             confs[idx] = 95
             reasons[idx] = "辞書候補1位一致"
             processed += 1


### PR DESCRIPTION
## Summary
- import `normalize_for_keypuncher_check`
- compare Sudachi and GPT readings using the keypuncher normalization
- adjust `calc_confidence` to rely on the new normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762424afc883338f234e19acba6ef8