### PR TITLE
Switch default model to gpt-4.1-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Set your OpenAI API key:
 export OPENAI_API_KEY="sk-..."
 ```
 
-Optionally choose the OpenAI model (defaults to `gpt-4o-mini`):
+Optionally choose the OpenAI model (defaults to `gpt-4.1-mini-2025-04-14`):
 
 ```bash
 export OPENAI_MODEL="gpt-3.5-turbo"
@@ -53,7 +53,7 @@ produce consistent results:
 
 ### Candidate Generation
 
-Unknown names are sent to GPT-4o mini three times with increasing temperatures.
+Unknown names are sent to GPT-4.1 mini (knowledge cutoff 2025-04-14) three times with increasing temperatures.
 The first request uses ``temperature=0.0`` and returns three candidates.
 The second uses ``temperature=0.2`` to get five more. A final call at
 ``temperature=0.5`` provides another five. Duplicate readings are removed

--- a/README_ja.md
+++ b/README_ja.md
@@ -18,6 +18,8 @@
    ```bash
    export OPENAI_API_KEY="sk-..."
    ```
+   デフォルトのモデルは `gpt-4.1-mini-2025-04-14` （ナレッジカットオフ 2025-04-14）です。
+   必要に応じて `OPENAI_MODEL` 環境変数で変更できます。
 4. 以下のコマンドでアプリを起動します。
    ```bash
    streamlit run app.py

--- a/core/scorer.py
+++ b/core/scorer.py
@@ -10,7 +10,8 @@ from functools import lru_cache
 
 client = openai.OpenAI()
 async_client = openai.AsyncOpenAI()
-DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+# Default model uses GPT-4.1 mini with knowledge cutoff 2025-04-14
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini-2025-04-14")
 
 # regex for the first katakana sequence; also accepts half/full-width digits
 # match contiguous katakana or full/half width digits

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -102,7 +102,7 @@ def test_default_model_when_env_missing(monkeypatch):
     import importlib
 
     mod = importlib.reload(scorer)
-    assert mod.DEFAULT_MODEL == "gpt-4o-mini"
+    assert mod.DEFAULT_MODEL == "gpt-4.1-mini-2025-04-14"
 
 
 def test_async_gpt_candidates():


### PR DESCRIPTION
## Summary
- default to `gpt-4.1-mini-2025-04-14`
- document new model and knowledge cutoff in README files
- update processing instructions for the new model
- adjust tests for new default

## Testing
- `pip install sudachipy sudachidict-full openai pandas streamlit openpyxl xlsxwriter jaconv pytest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876447989b48333bb2853c4c9615f02