### PR TITLE
Remove unused normalize_kana import

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pandas as pd
 from io import BytesIO
 from . import parser, scorer, db
-from .normalize import normalize_kana, normalize_for_keypuncher_check
+from .normalize import normalize_for_keypuncher_check
 import sqlite3
 import asyncio
 from asyncio import Semaphore


### PR DESCRIPTION
## Summary
- cleanup: drop unused `normalize_kana` import from `core/utils.py`

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6876665935b48333a108db31ef15ff03