### PR TITLE
Implement scored candidate evaluation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openpyxl
 xlsxwriter
 jaconv
 pytest
+python-Levenshtein


### PR DESCRIPTION
## Summary
- add python-Levenshtein to requirements
- extend scorer with new `Scorer` class for multi-agent results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687727fe9a948333af02efabf68db407